### PR TITLE
Better cross plat and editor context menu integration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The extension can also be executed on demand
 - **Mac**: <kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>O</kbd>
 - **Windows**: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>O</kbd>
 
+The command could also be found in the command palette (named `Open with default application`), or on the contextual menu in the file explorer.
+
 
 ## Roadmap
 

--- a/package.json
+++ b/package.json
@@ -34,9 +34,17 @@
     "commands": [
       {
         "command": "extension.open",
-        "title": "Open"
+        "title": "Open with default application"
       }
     ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "extension.open",
+          "group": "navigation"
+        }
+      ]
+    },
     "keybindings": [
       {
         "command": "extension.open",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "vscode": "0.10.x"
   },
   "dependencies": {
-    "open": "0.0.5"
+    "opn": "^4.0.2"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-const open = require('open');
+const opn = require('opn');
 
 /**
  * Activates the extension.
@@ -40,7 +40,7 @@ class OpenController {
     }
 
     try {
-      open(decodeURIComponent(editor.document.uri.toString()));
+      opn(decodeURIComponent(editor.document.uri.toString()));
     }
     catch (error) {
       vscode.window.showInformationMessage('Couldn\'t open file.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,8 +19,8 @@ class OpenController {
   constructor() {
 
     let subscriptions: vscode.Disposable[] = [];
-    let disposable = vscode.commands.registerCommand('extension.open', () => {
-      this.openNow();
+    let disposable = vscode.commands.registerCommand('extension.open', (uri: vscode.Uri) => {
+      this.openNow(uri);
     });
     subscriptions.push(disposable);
 
@@ -31,16 +31,18 @@ class OpenController {
     this._disposable.dispose();
   }
 
-  openNow(){
-
-    let editor = vscode.window.activeTextEditor;
-    if (!editor || !editor.document.uri) {
-      vscode.window.showInformationMessage('No editor is active.');
-      return;
+  openNow(uri: vscode.Uri){
+    if (!uri || !uri.scheme) { // uri isn't a real URI. This means that the user called the action within the editor
+      let editor = vscode.window.activeTextEditor;
+      if (!editor || !editor.document.uri) {
+        vscode.window.showInformationMessage('No editor is active.');
+        return;
+      }
+      uri = editor.document.uri;
     }
 
     try {
-      opn(decodeURIComponent(editor.document.uri.toString()));
+      opn(decodeURIComponent(uri.toString()));
     }
     catch (error) {
       vscode.window.showInformationMessage('Couldn\'t open file.');


### PR DESCRIPTION
Hello,
I had some problems, and also some solutions:

- With my OS (Ubuntu) the open module from npm does not work that well (depending on the application and bla bla). I see that using opn instead solves the problem.
- There's a relatively new api to integrate to the context menu. So now we can right-click on the file explorer.

Feel free to ask/integrate/disintegrate...
Bye!