### PR TITLE
Added WSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# vscode-open
+# Open with Default Application (WSL supported)
 
-> Opens files using the OS's default program for the file type
+> Opens files using the OS's (in Windows for WSL) default program for the file type
+
+ - This is forked version of [open by sandcastle](https://marketplace.visualstudio.com/items?itemName=sandcastle.vscode-open) with WSL support added
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-open-wsl",
   "displayName": "Open (WSL support)",
   "description": "Opens the current file with the default application for the OS (in Windows for WSL)",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "icon": "open.png",
   "publisher": "NoThlnG",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "vscode-open",
+  "name": "vscode-open-wsl",
   "displayName": "Open",
-  "description": "Opens the current file with the default for the OS",
-  "version": "0.2.0",
+  "description": "Opens the current file with the default application for the OS (in Windows for WSL)",
+  "version": "0.2.1",
   "icon": "open.png",
-  "publisher": "sandcastle",
+  "publisher": "IndlgO",
   "engines": {
     "vscode": "^1.50.0"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sandcastle/vscode-open"
+    "url": "https://github.com/Indlgo/vscode-open"
   },
   "keywords": [
     "open",
@@ -19,42 +19,42 @@
     "display",
     "vscode"
   ],
-  "homepage": "https://github.com/sandcastle/vscode-open",
+  "homepage": "https://github.com/Indlgo/vscode-open",
   "bugs": {
-    "url": "https://github.com/sandcastle/vscode-open/issues"
+    "url": "https://github.com/Indlgo/vscode-open/issues"
   },
   "categories": [
     "Other"
   ],
   "activationEvents": [
-    "onCommand:workbench.action.files.openFileWithDefaultApplication"
+    "onCommand:openWithDefaultApplication.open"
   ],
   "main": "./out/src/extension",
   "contributes": {
     "commands": [
       {
-        "command": "workbench.action.files.openFileWithDefaultApplication",
+        "command": "openWithDefaultApplication.open",
         "title": "Open with default application"
       }
     ],
     "menus": {
       "explorer/context": [
         {
-          "command": "workbench.action.files.openFileWithDefaultApplication",
+          "command": "openWithDefaultApplication.open",
           "group": "navigation",
           "when": "explorerResourceIsFolder == false"
         }
       ],
       "commandPalette": [
         {
-          "command": "workbench.action.files.openFileWithDefaultApplication",
+          "command": "openWithDefaultApplication.open",
           "when": "resourceSet"
         }
       ]
     },
     "keybindings": [
       {
-        "command": "workbench.action.files.openFileWithDefaultApplication",
+        "command": "openWithDefaultApplication.open",
         "key": "ctrl+alt+o",
         "mac": "cmd+alt+o"
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "vscode-open-wsl",
-  "displayName": "Open",
+  "displayName": "Open (WSL support)",
   "description": "Opens the current file with the default application for the OS (in Windows for WSL)",
   "version": "0.2.1",
   "icon": "open.png",
-  "publisher": "IndlgO",
+  "publisher": "NoThlnG",
   "engines": {
     "vscode": "^1.50.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,15 +31,32 @@ class OpenController implements vscode.Disposable {
     this._disposable.dispose();
   }
 
+  private openWslFile(uri: vscode.Uri): boolean {
+    if (vscode.env?.remoteName === 'wsl' && process.env?.WSL_DISTRO_NAME) {
+      const baseUri = vscode.Uri.parse(`${uri.scheme}://${vscode.env.remoteName}\$/${process.env.WSL_DISTRO_NAME}`)
+      this.openFile(vscode.Uri.joinPath(baseUri, uri.fsPath).toString());
+      return true;
+    }
+    return false;
+  }
+
   private open(uri: vscode.Uri | undefined): void {
 
     if (uri?.scheme) {
+      if (this.openWslFile(uri)) {
+        return;
+      }
+
       this.openFile(uri.toString());
       return;
     }
 
     const editor = vscode.window.activeTextEditor;
     if (editor?.document.uri) {
+      if (this.openWslFile(editor.document.uri)) {
+        return;
+      }
+
       this.openFile(editor.document.uri.toString());
       return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ class OpenController implements vscode.Disposable {
   constructor() {
 
     const subscriptions: vscode.Disposable[] = [];
-    const disposable = vscode.commands.registerCommand('workbench.action.files.openFileWithDefaultApplication', (uri: vscode.Uri | undefined) => {
+    const disposable = vscode.commands.registerCommand('openWithDefaultApplication.open', (uri: vscode.Uri | undefined) => {
       this.open(uri);
     });
     subscriptions.push(disposable);


### PR DESCRIPTION
Hi, your plugin didn't work as expected on WSL environment and I've tried to make it work.

One thing to consider is that it uses $WSL_DISTRO_NAME environment variable to detect the WSL distro name which is available since WSL builds 18362 (WSL2). So it might not work for older builds.
