### PR TITLE
Add support for opening folders + configuration to make it optional

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
   "search.exclude": {
     "out": true // set this to false to include "out" folder in search results
   },
-  "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
+  "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
+  "editor.tabSize": 2 // Set project tab size for developers who use different values
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-open",
   "displayName": "Open",
-  "description": "Opens the current file with the default for the OS",
+  "description": "Opens the current file or folder with the default for the OS",
   "version": "0.3.0",
   "icon": "open.png",
   "publisher": "sandcastle",
@@ -27,7 +27,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:workbench.action.files.openFileWithDefaultApplication"
+    "*"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -42,7 +42,7 @@
         {
           "command": "workbench.action.files.openFileWithDefaultApplication",
           "group": "navigation",
-          "when": "explorerResourceIsFolder == false"
+          "when": "(vscode-open.allowContextMenuForFile && !explorerResourceIsFolder) || (vscode-open.allowContextMenuForFolder && explorerResourceIsFolder)"
         }
       ],
       "commandPalette": [
@@ -58,7 +58,22 @@
         "key": "ctrl+alt+o",
         "mac": "cmd+alt+o"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Open with default application",
+      "properties": {
+        "vscode-open.contextMenu.showForFiles": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show `Open with default application` for files"
+        },
+        "vscode-open.contextMenu.showForFolders": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to show `Open with default application` for folders"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         {
           "command": "workbench.action.files.openFileWithDefaultApplication",
           "group": "navigation",
-          "when": "(vscode-open.allowContextMenuForFile && !explorerResourceIsFolder) || (vscode-open.allowContextMenuForFolder && explorerResourceIsFolder)"
+          "when": "(vscode-open:allowContextMenuForFile && !explorerResourceIsFolder) || (vscode-open:allowContextMenuForFolder && explorerResourceIsFolder)"
         }
       ],
       "commandPalette": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,23 @@ class OpenController implements vscode.Disposable {
     subscriptions.push(disposable);
 
     this._disposable = vscode.Disposable.from(...subscriptions);
+    function setContext() {
+      const config = vscode.workspace.getConfiguration('vscode-open');
+      const showForFiles: boolean = config.get('contextMenu.showForFiles') ?? true;
+      const showForFolders: boolean = config.get('contextMenu.showForFolders') ?? false;
+      vscode.commands.executeCommand(
+        'setContext',
+        'vscode-open:allowContextMenuForFile',
+        showForFiles
+      );
+      vscode.commands.executeCommand(
+        'setContext',
+        'vscode-open:allowContextMenuForFolder',
+        showForFolders
+      );
+    }
+    setContext();
+    vscode.workspace.onDidChangeConfiguration(setContext)
   }
 
   dispose(): void {


### PR DESCRIPTION
I used this extension to open folders, and got really used to it.
A few updates ago the `when` clause was added and limited the behavior to files only.
In this pull request I'm adding that again, as an optional feature of course. I also added configuration for both files and folders to show or hide the context menu button.
Default behavior doesn't change, as the configuration is set to show the button for files by default, but not show it for folders.