### PR TITLE
feat: enable it to open multiple files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,8 +19,8 @@ class OpenController implements vscode.Disposable {
   constructor() {
 
     const subscriptions: vscode.Disposable[] = [];
-    const disposable = vscode.commands.registerCommand('workbench.action.files.openFileWithDefaultApplication', (uri: vscode.Uri | undefined) => {
-      this.open(uri);
+    const disposable = vscode.commands.registerCommand('workbench.action.files.openFileWithDefaultApplication', (uri: vscode.Uri | undefined, uris: vscode.Uri[] | undefined) => {
+      this.open(uri, uris);
     });
     subscriptions.push(disposable);
 
@@ -48,7 +48,16 @@ class OpenController implements vscode.Disposable {
     this._disposable.dispose();
   }
 
-  private open(uri: vscode.Uri | undefined): void {
+  private open(uri: vscode.Uri | undefined, uris: vscode.Uri[] | undefined): void {
+    if (uris && uris.some((uri) => uri?.scheme)) {
+      uris
+        .filter((uri) => uri?.scheme)
+        .forEach((uri) => {
+          console.log("Opening from uris", uri.toString());
+          this.openFile(uri.toString());
+        });
+      return;
+    }
 
     if (uri?.scheme) {
       console.log("Opening from uri", uri.toString());


### PR DESCRIPTION
Enable it to open multiple files

It's possible to get all selected files when running open command from context menu on explorer.
Here is a related code snippet on Stack Overflow:
- [VS Code extension api get all selected files](https://stackoverflow.com/questions/59457236/vs-code-extension-api-get-all-selected-files)
- [How to obtain a list of selected files from the explorer pane of VS Code?](https://stackoverflow.com/questions/75531992/how-to-obtain-a-list-of-selected-files-from-the-explorer-pane-of-vs-code)

Test
1. Select two text files.
2. Run open command from context menu.
3. Two text files opened.
![test-video](https://github.com/sandcastle/vscode-open/assets/84499939/630f8c08-48a3-40d9-919d-a5e582f4308e)

I'm very new to pull request, I welcome any feedback.