### PR TITLE
add localization and support japanese

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "commands": [
       {
         "command": "workbench.action.files.openFileWithDefaultApplication",
-        "title": "Open with default application"
+        "title": "%openFileWithDefaultApplication%"
       }
     ],
     "menus": {

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,0 +1,3 @@
+{
+  "openFileWithDefaultApplication": "デフォルトのアプリで開く"
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,0 +1,3 @@
+{
+  "openFileWithDefaultApplication": "Open with default application"
+}


### PR DESCRIPTION
I have added multi-language support to the right-click menu of this extension, making it available in Japanese. However, I am not familiar with VScode extensions, so there may be mistakes. If you find any mistakes, please do comment or contribute.